### PR TITLE
Adjust to GitHub style changes

### DIFF
--- a/content.css
+++ b/content.css
@@ -1,7 +1,3 @@
 table.files tbody tr.first td {
 	border-top: 0 !important;
 }
-
-.hide-files-btn {
-	margin-right: 5px;
-}

--- a/content.js
+++ b/content.js
@@ -28,8 +28,8 @@ function toggleFiles() {
 }
 
 function addToggleBtn() {
-	var toggleBtn = createHtml('<a class="hide-files-btn btn btn-sm right">Show Dotfiles</a>');
-	var btnContainer = document.querySelector('.file-navigation .breadcrumb');
+	var toggleBtn = createHtml('<a class="hide-files-btn btn btn-sm">Show .files</a>');
+	var btnContainer = document.querySelector('.file-navigation .right');
 
 	if (document.querySelector('.hide-files-btn')) {
 		return;
@@ -37,11 +37,11 @@ function addToggleBtn() {
 
 	if (btnContainer) {
 		// insert after
-		btnContainer.parentNode.insertBefore(toggleBtn, btnContainer.nextSibling);
+		btnContainer.insertBefore(toggleBtn, btnContainer.children[0]);
 
 		document.querySelector('.hide-files-btn').addEventListener('click', function (e) {
 			isHidden = !isHidden;
-			this.textContent = isHidden ? 'Show Dotfiles' : 'Hide Dotfiles';
+			this.textContent = isHidden ? 'Show .files' : 'Hide .files';
 			toggleFiles();
 		});
 	}


### PR DESCRIPTION
Fixes #18.

I haven't bumped the version because there still is a week to go before Github's new styles rolls around for everyone. 

Also, this breaks backward compatibility with the old Github styles. There probably is a reliable way to differentiate between the old and new styles, but as the switch to the new styles is going to become mandatory soon, I decided not to spend time figuring it out.